### PR TITLE
Prevent old local files from overriding files on the wombat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,11 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "fs-extra": "^11.3.0"
+      },
       "devDependencies": {
+        "@types/fs-extra": "^11.0.4",
         "lerna": "^8.1.9",
         "nodemon": "^3.1.9",
         "typescript": "^5.7.3"
@@ -4078,6 +4082,17 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -4091,6 +4106,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -7911,7 +7936,6 @@
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
       "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -9286,7 +9310,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -14229,7 +14252,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,13 @@
   },
   "private": true,
   "devDependencies": {
+    "@types/fs-extra": "^11.0.4",
     "lerna": "^8.1.9",
     "nodemon": "^3.1.9",
     "typescript": "^5.7.3"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "fs-extra": "^11.3.0"
+  }
 }

--- a/packages/extension/src/api.ts
+++ b/packages/extension/src/api.ts
@@ -139,9 +139,7 @@ export class API {
      * @returns the file data
      */
     public static async getFile(filepath: string) {
-        console.log('http://192.168.125.1:8888/api/fs' + filepath);
         let apiUrl: string = 'http://192.168.125.1:8888/api/fs' + filepath;
-        console.log(apiUrl);
         let apiResult: any = await axios.get(apiUrl);
         if (apiResult.status === 200) {
             return apiResult.data;

--- a/packages/extension/src/api.ts
+++ b/packages/extension/src/api.ts
@@ -139,7 +139,9 @@ export class API {
      * @returns the file data
      */
     public static async getFile(filepath: string) {
+        console.log('http://192.168.125.1:8888/api/fs' + filepath);
         let apiUrl: string = 'http://192.168.125.1:8888/api/fs' + filepath;
+        console.log(apiUrl);
         let apiResult: any = await axios.get(apiUrl);
         if (apiResult.status === 200) {
             return apiResult.data;

--- a/packages/extension/src/sidebarProvider.ts
+++ b/packages/extension/src/sidebarProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { API } from './api';
 import os from 'os';
 import fs from 'fs';
+import { backupProject } from './util';
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
     private static instance: SidebarProvider | null = null;
@@ -303,6 +304,15 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                             }
                         });
                     break;
+                case 'backup-project':
+                    const path: string =
+                        os.tmpdir() +
+                        '/vscode_wombat_ext/' +
+                        data.username +
+                        '/' +
+                        data.projectname;
+
+                    backupProject(path);
             }
         });
     }

--- a/packages/extension/src/sidebarProvider.ts
+++ b/packages/extension/src/sidebarProvider.ts
@@ -2,7 +2,8 @@ import * as vscode from 'vscode';
 import { API } from './api';
 import os from 'os';
 import fs from 'fs';
-import { backupProject } from './util';
+import { downloadFile, saveAndBackupProject } from './util';
+import { ProjectModel } from '../../shared/models/projectModel';
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
     private static instance: SidebarProvider | null = null;
@@ -201,38 +202,10 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                     });
                     break;
                 case 'open-file':
-                    let username: string = data.username;
-                    let projectname: string = data.projectname;
-
-                    let getFileData: any = await API.getFile(data.filepath);
-
-                    let fileDir: string =
-                        os.tmpdir() +
-                        '/vscode_wombat_ext/' +
-                        username +
-                        '/' +
-                        projectname;
-
-                    if (!fs.existsSync(fileDir)) {
-                        fs.mkdirSync(fileDir, { recursive: true });
-                    }
-
-                    let codeFilePath: string = fileDir + '/' + getFileData.name;
-
-                    let configData: any = {
-                        filepathOnWombat: getFileData.path,
-                        username,
-                        projectname,
-                    };
-
-                    let configFilepath: string =
-                        fileDir + '/' + getFileData.name + '.json';
-
-                    let decodedFileContent: string = atob(getFileData.content);
-                    fs.writeFileSync(codeFilePath, decodedFileContent);
-                    fs.writeFileSync(
-                        configFilepath,
-                        JSON.stringify(configData)
+                    const codeFilePath = await downloadFile(
+                        data.username,
+                        data.projectname,
+                        data.filepath
                     );
 
                     await vscode.window.showTextDocument(
@@ -304,15 +277,21 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
                             }
                         });
                     break;
-                case 'backup-project':
+                case 'save-backup-project':
                     const path: string =
                         os.tmpdir() +
                         '/vscode_wombat_ext/' +
                         data.username +
                         '/' +
                         data.projectname;
+                    const project = JSON.parse(data.project) as ProjectModel;
 
-                    backupProject(path);
+                    saveAndBackupProject(
+                        data.username,
+                        data.projectname,
+                        path,
+                        project
+                    );
             }
         });
     }

--- a/packages/extension/src/util.ts
+++ b/packages/extension/src/util.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import fse from 'fs-extra';
+
+export function backupProject(projectDir: string) {
+    try {
+        if (!fs.existsSync(projectDir)) {
+            return;
+        }
+    } catch (e) {
+        return;
+    }
+
+    const backupPath = `${projectDir}.bak`;
+
+    if (fs.existsSync(backupPath)) {
+        fs.rmdirSync(backupPath);
+    }
+
+    fse.copySync(projectDir, backupPath);
+}

--- a/packages/extension/src/util.ts
+++ b/packages/extension/src/util.ts
@@ -4,12 +4,22 @@ import { API } from './api';
 import os from 'node:os';
 import { ProjectModel } from '../../shared/models/projectModel';
 
+/**
+ * Backups a project and re-downloads files, so files
+ * on the server wont be overridden
+ *
+ * If a project doesn't exist locally, it returns
+ * @param username
+ * @param projectname
+ * @param projectDir project directory
+ * @param project ProjectModel
+ */
 export function saveAndBackupProject(
     username: string,
     projectname: string,
     projectDir: string,
     project: ProjectModel
-) {
+): void {
     try {
         if (!fs.existsSync(projectDir)) {
             return;

--- a/packages/shared/models/projectModel.ts
+++ b/packages/shared/models/projectModel.ts
@@ -2,9 +2,10 @@ export interface ProjectModel {
   name: string;
   links: Links;
   parameters: Parameters;
-  include_files: any[];
+  include_files: IncludeFile[];
   source_files: SourceFile[];
   data_files: any[];
+  binary_files: BinaryFile[];
 }
 
 export interface Links {
@@ -55,7 +56,7 @@ export interface Parameters {
   user: string;
 }
 
-export interface SourceFile {
+export interface IncludeFile {
   name: string;
   path: string;
   type: string;
@@ -67,5 +68,137 @@ export interface Links2 {
 }
 
 export interface Self2 {
+  href: string;
+}
+
+export interface SourceFile {
+  name: string;
+  path: string;
+  type: string;
+  links: Links3;
+}
+
+export interface Links3 {
+  self: Self3;
+}
+
+export interface Self3 {
+  href: string;
+}
+
+export interface BinaryFile {
+  name: string;
+  path: string;
+  type: string;
+  links: Links4;
+}
+
+export interface Links4 {
+  self: Self4;
+}
+
+export interface Self4 {
+  href: string;
+}
+export interface Root {
+  name: string;
+  links: Links;
+  parameters: Parameters;
+  include_files: IncludeFile[];
+  source_files: SourceFile[];
+  data_files: any[];
+  binary_files: BinaryFile[];
+}
+
+export interface Links {
+  project_file: ProjectFile;
+  include_directory: IncludeDirectory;
+  src_directory: SrcDirectory;
+  data_directory: DataDirectory;
+  bin_directory: BinDirectory;
+  binary: Binary;
+  lib_directory: LibDirectory;
+  self: Self;
+}
+
+export interface ProjectFile {
+  href: string;
+}
+
+export interface IncludeDirectory {
+  href: string;
+}
+
+export interface SrcDirectory {
+  href: string;
+}
+
+export interface DataDirectory {
+  href: string;
+}
+
+export interface BinDirectory {
+  href: string;
+}
+
+export interface Binary {
+  href: string;
+}
+
+export interface LibDirectory {
+  href: string;
+}
+
+export interface Self {
+  href: string;
+}
+
+export interface Parameters {
+  language: string;
+  user: string;
+}
+
+export interface IncludeFile {
+  name: string;
+  path: string;
+  type: string;
+  links: Links2;
+}
+
+export interface Links2 {
+  self: Self2;
+}
+
+export interface Self2 {
+  href: string;
+}
+
+export interface SourceFile {
+  name: string;
+  path: string;
+  type: string;
+  links: Links3;
+}
+
+export interface Links3 {
+  self: Self3;
+}
+
+export interface Self3 {
+  href: string;
+}
+
+export interface BinaryFile {
+  name: string;
+  path: string;
+  type: string;
+  links: Links4;
+}
+
+export interface Links4 {
+  self: Self4;
+}
+
+export interface Self4 {
   href: string;
 }

--- a/packages/webview/src/App.vue
+++ b/packages/webview/src/App.vue
@@ -120,17 +120,12 @@ async function reload() {
   await loadProjectsByCurrentUser();
 }
 
-async function onProjectChange(username: string, projectname: string) {
-  return new Promise((resolve) => {
-    addOneTimeCodeListenerPromise('backup-project', () => {
-      resolve(undefined);
-    });
-
-    vscode.postMessage({
-      type: 'backup-project',
-      username,
-      projectname,
-    });
+function onProjectChange(username: string, projectname: string) {
+  vscode.postMessage({
+    type: 'save-backup-project',
+    username,
+    projectname,
+    project: JSON.stringify(currentProject.value),
   });
 }
 
@@ -192,6 +187,7 @@ function openFile(path: string) {
     filepath: path,
     username: currentUsername.value,
     projectname: currentProject.value?.name,
+    project: JSON.stringify(currentProject.value),
   });
 }
 

--- a/packages/webview/src/App.vue
+++ b/packages/webview/src/App.vue
@@ -187,7 +187,6 @@ function openFile(path: string) {
     filepath: path,
     username: currentUsername.value,
     projectname: currentProject.value?.name,
-    project: JSON.stringify(currentProject.value),
   });
 }
 

--- a/packages/webview/src/App.vue
+++ b/packages/webview/src/App.vue
@@ -83,7 +83,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, type ComputedRef, type Ref } from 'vue';
+import { computed, onMounted, ref, watch, type ComputedRef, type Ref } from 'vue';
 import { type ProjectModel } from '../../shared/models/projectModel';
 
 const vscode = acquireVsCodeApi();
@@ -102,17 +102,36 @@ const usernames = ref([] as string[]);
 const projectLinks = ref([] as any[]);
 const projects = ref([] as ProjectModel[]);
 
-onMounted(() => {
-  reload();
-});
-
 const currentProject: ComputedRef<ProjectModel | undefined> = computed(() =>
   projects.value.find((project) => project.name === currentProjectName.value),
 );
 
+onMounted(() => {
+  reload();
+});
+
+watch(currentProjectName, () => {
+  if (!!currentProjectName.value && !!currentUsername.value)
+    onProjectChange(currentUsername.value, currentProjectName.value);
+});
+
 async function reload() {
   await loadUsers();
   await loadProjectsByCurrentUser();
+}
+
+async function onProjectChange(username: string, projectname: string) {
+  return new Promise((resolve) => {
+    addOneTimeCodeListenerPromise('backup-project', () => {
+      resolve(undefined);
+    });
+
+    vscode.postMessage({
+      type: 'backup-project',
+      username,
+      projectname,
+    });
+  });
 }
 
 async function loadUsers() {


### PR DESCRIPTION
Due to the wombat files being stored locally in a temporary directory, they can override changes made from another device or the web gui, if they are not redownloaded. This fix will try to prevent this behaviour by backing up the local changes on a separate directory (`existing directory` + `.bak`) and then redownloading the files in the original directory.